### PR TITLE
[🐸 Frogbot] Update version of org.jruby:jruby to 10.0.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This document describes how you can contribute to WebGoat. Please read it carefu
 * [How to set up your Contributor Environment](#how-to-set-up-your-contributor-environment)
 * [How to get your PR Accepted](#how-to-get-your-pr-accepted)
 
-## How to Contribute to the project
+## How to Contribute to the projectddd
 
 There are a couple of ways on how you can contribute to the project:
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
       <dependency>
         <groupId>org.jruby</groupId>
         <artifactId>jruby</artifactId>
-        <version>9.4.9.0</version>
+        <version>10.0.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.playwright</groupId>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2025-46551 | org.asciidoctor:asciidoctorj:3.0.0 | org.jruby:jruby 9.4.9.0 | [10.0.0.1]<br>[9.4.12.1] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Direct Dependencies:** | org.asciidoctor:asciidoctorj:3.0.0 |
| **Impacted Dependency:** | org.jruby:jruby:9.4.9.0 |
| **Fixed Versions:** | [10.0.0.1], [9.4.12.1] |
| **CVSS V3:** | - |

JRuby-OpenSSL is an add-on gem for JRuby that emulates the Ruby OpenSSL native library. Starting in JRuby-OpenSSL version 0.12.1 and prior to version 0.15.4 (corresponding to JRuby versions starting in 9.3.4.0 prior to 9.4.12.1 and 10.0.0.0 prior to 10.0.0.1), when verifying SSL certificates, JRuby-OpenSSL does not verify that the hostname presented in the certificate matches the one the user tries to connect to. This means a man-in-the-middle could just present any valid cert for a completely different domain they own, and JRuby would accept the cert. Anybody using JRuby to make requests of external APIs, or scraping the web, that depends on https to connect securely. JRuby-OpenSSL version 0.15.4 contains a fix for the issue. This fix is included in JRuby versions 10.0.0.1 and 9.4.12.1.
<details><summary><b>Note</b></summary>

---
<div align='center'>

**Frogbot** also supports **Contextual Analysis, Secret Detection, IaC and SAST Vulnerabilities Scanning**. This features are included as part of the [JFrog Advanced Security](https://jfrog.com/advanced-security) package, which isn't enabled on your system.

</div>
<br></details>

---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
