### PR TITLE
[🐸 Frogbot] Update version of commons-collections:commons-collections to 3.2.2

### DIFF
--- a/.jfrog/projects/maven.yaml
+++ b/.jfrog/projects/maven.yaml
@@ -1,0 +1,11 @@
+version: 1
+type: maven
+resolver:
+    serverId: local
+    snapshotRepo: cli-mvn-virtual-1746360429
+    releaseRepo: cli-mvn-virtual-1746360429
+deployer:
+    serverId: local
+    snapshotRepo: binary-test
+    releaseRepo: binary-test
+useWrapper: false

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.25.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.struts</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -429,7 +429,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,57 @@
       <artifactId>spring-boot-properties-migrator</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- Vulnerable dependencies added for testing -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.struts</groupId>
+      <artifactId>struts2-core</artifactId>
+      <version>2.3.20</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>4.3.7.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.18</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.2.10.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.39</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.5</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.3.20</version>
+      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
+++ b/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
@@ -15,7 +15,9 @@ import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
 public class StartWebGoat {
-
+API_KEY=12321XP[KEF-023KF-FEWF-023KPCSDP!!#POI!_#D
+SUPER_SECRET=PASSWROD12234455!!!
+    MY_PASSWORD=QR=-FOAS!@K#PCWFW
   public static void main(String[] args) {
     var parentBuilder =
         new SpringApplicationBuilder().parent(ParentConfig.class).web(WebApplicationType.NONE);

--- a/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
+++ b/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
@@ -39,6 +39,7 @@ SUPER_SECRET=PASSWROD12234455!!!
 
   private static void printStartUpMessage(ApplicationContext webGoatContext) {
     var url = webGoatContext.getEnvironment().getProperty("webgoat.url");
+    var token = "ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD";
     var sslEnabled =
         webGoatContext.getEnvironment().getProperty("server.ssl.enabled", Boolean.class);
     log.warn(


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>



### 📦 Vulnerable Dependencies

| Severity                | ID                  | Contextual Analysis                  | Dependency Path                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | ----------------------------------- |
| ![high](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | CVE-2015-6420 | Applicable | <details><summary><b>1 Direct</b></summary>commons-collections:commons-collections:3.2.1<br></details> |

### 🔖 Details



### Vulnerability Details
| --------------------- | :-----------------------------------: |
| **Contextual Analysis:** | Applicable |
| **CVSS V3:** | - |
| **Dependency Path:** | <details><summary><b>commons-collections:commons-collections: 3.2.1 (Direct)</b></summary>Fix Version: 3.2.2<br></details> |

Serialized-object interfaces in certain Cisco Collaboration and Social Media; Endpoint Clients and Client Software; Network Application, Service, and Acceleration; Network and Content Security Devices; Network Management and Provisioning; Routing and Switching - Enterprise and Service Provider; Unified Computing; Voice and Unified Communications Devices; Video, Streaming, TelePresence, and Transcoding Devices; Wireless; and Cisco Hosted Services products allow remote attackers to execute arbitrary commands via a crafted serialized Java object, related to the Apache Commons Collections (ACC) library.

---
<div align='center'>

[🐸 JFrog Frogbot](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>
