### PR TITLE
[🐸 Frogbot] Update version of org.bitbucket.b_c:jose4j to 0.9.6

### DIFF
--- a/.jfrog/projects/maven.yaml
+++ b/.jfrog/projects/maven.yaml
@@ -1,0 +1,11 @@
+version: 1
+type: maven
+resolver:
+    serverId: local
+    snapshotRepo: cli-mvn-virtual-1746360429
+    releaseRepo: cli-mvn-virtual-1746360429
+deployer:
+    serverId: local
+    snapshotRepo: binary-test
+    releaseRepo: binary-test
+useWrapper: false

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>${xstream.version}</version>
+        <version>1.4.21</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.25.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.struts</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -429,7 +429,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.39</version>
+      <version>8.0.33</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,57 @@
       <artifactId>spring-boot-properties-migrator</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- Vulnerable dependencies added for testing -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.struts</groupId>
+      <artifactId>struts2-core</artifactId>
+      <version>2.3.20</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>4.3.7.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.18</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.2.10.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.39</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.5</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.5</version>
+      <version>42.3.3</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.2.10.Final</version>
+      <version>6.2.36.Final</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.3.20</version>
+      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
       <dependency>
         <groupId>org.bitbucket.b_c</groupId>
         <artifactId>jose4j</artifactId>
-        <version>${jose4j.version}</version>
+        <version>0.9.6</version>
       </dependency>
       <dependency>
         <groupId>org.webjars</groupId>

--- a/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
+++ b/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
@@ -15,7 +15,9 @@ import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
 public class StartWebGoat {
-
+API_KEY=12321XP[KEF-023KF-FEWF-023KPCSDP!!#POI!_#D
+SUPER_SECRET=PASSWROD12234455!!!
+    MY_PASSWORD=QR=-FOAS!@K#PCWFW
   public static void main(String[] args) {
     var parentBuilder =
         new SpringApplicationBuilder().parent(ParentConfig.class).web(WebApplicationType.NONE);

--- a/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
+++ b/src/main/java/org/owasp/webgoat/server/StartWebGoat.java
@@ -39,6 +39,7 @@ SUPER_SECRET=PASSWROD12234455!!!
 
   private static void printStartUpMessage(ApplicationContext webGoatContext) {
     var url = webGoatContext.getEnvironment().getProperty("webgoat.url");
+    var token = "ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD";
     var sslEnabled =
         webGoatContext.getEnvironment().getProperty("server.ssl.enabled", Boolean.class);
     log.warn(


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>



### 📦 Vulnerable Dependencies

| Severity                | ID                  | Contextual Analysis                  | Dependency Path                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | ----------------------------------- |
| ![high](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | CVE-2024-29371 | Applicable | <details><summary><b>1 Direct</b></summary>org.bitbucket.b_c:jose4j:0.9.3<br></details> |

### 🔖 Details



### Vulnerability Details
| --------------------- | :-----------------------------------: |
| **Contextual Analysis:** | Applicable |
| **CVSS V3:** | - |
| **Dependency Path:** | <details><summary><b>org.bitbucket.b_c:jose4j: 0.9.3 (Direct)</b></summary>Fix Version: 0.9.6<br></details> |

In jose4j before 0.9.6, an attacker can cause a Denial-of-Service (DoS) condition by crafting a malicious JSON Web Encryption (JWE) token with an exceptionally high compression ratio. When this token is processed by the server, it results in significant memory allocation and processing time during decompression.

---
<div align='center'>

[🐸 JFrog Frogbot](https://jfrog.com/help/r/jfrog-security-user-guide/shift-left-on-security/frogbot)

</div>
