### PR TITLE
[🐸 Frogbot] Update version of org.bitbucket.b_c:jose4j to 0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <java.version>25</java.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jjwt.version>0.9.1</jjwt.version>
-    <jose4j.version>0.9.3</jose4j.version>
+    <jose4j.version>0.9.5</jose4j.version>
     <jquery.version>3.7.1</jquery.version>
     <jsoup.version>1.19.1</jsoup.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | Applicable | org.bitbucket.b_c:jose4j:0.9.3 | org.bitbucket.b_c:jose4j 0.9.3 | [0.9.5] | CVE-2024-29371 |

</div>


### 🔬 Research Details


**Description:**
[jose4j](https://bitbucket.org/b_c/jose4j/src/master/) is a robust Java library used for open source implementation of JSON Web Token (JWT) and the JOSE specification suite (JWS, JWE, and JWK) which relies solely on the JCA APIs for cryptography.

The flaw was in the `decompress()` function in the `DeflateRFC1951CompressionAlgorithm` class, responsible for processing compressed JWE tokens, which was missing a check on the decompressed output length. 

The unbounded decompression of a payload allows a malicious sender to provide a token with an extreme compression ratio, leading to excessive memory consumption during the expansion process and can cause a denial of service.

Any application using the vulnerable `jose4j` library that accepts JWE tokens from an untrusted source, attempts to decrypt them, and reads the decompressed data, is vulnerable:

```
JsonWebEncryption receiverJwe = new JsonWebEncryption();
receiverJwe.setCompactSerialization(untrustedJweString);
receiverJwe.setKey(decryptionKey);
// This call triggers the unbounded decompression
String data = receiverJwe.getPlaintextString(); 
```

The attacker can craft a malicious JWE token `untrustedJweString` that expands significantly upon decompression:

```
Header: {"alg":"A128GCMKW","enc":"A128CBC-HS256","zip":"DEF"}
Payload: [Encrypted "A" * 100,000,000]
```

This leads to forced excessive allocations of memory for the decompressed data in the internal buffer, which can cause a crash and may leave the server unresponsive to other users.

Exploitation is highly likely for applications that process tokens from unauthenticated users (such as login or password reset endpoints) since an attacker only has to send a small JWE token with a high compression ratio.

**Remediation:**
##### Development mitigations

Reject tokens that use compression:

```
import org.jose4j.jwx.JsonWebStructure;

public boolean isCompressed(String untrustedJwe) {
    try {
        JsonWebStructure jwx = JsonWebStructure.fromCompactSerialization(untrustedJwe);
        String zip = jwx.getHeader("zip");
        
        return "DEF".equalsIgnoreCase(zip);
    } catch (Exception e) {
        return false;
    }
}
```


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
